### PR TITLE
feat(DP-4): Implement Contact Page

### DIFF
--- a/.reports/jest_execution_logs.txt
+++ b/.reports/jest_execution_logs.txt
@@ -1,0 +1,78 @@
+
+> react-boilerplate@0.1.0 test
+> react-scripts test --watchAll=false
+
+PASS src/App.test.jsx
+PASS src/components/__tests__/Header.test.jsx
+  ● Console
+
+    console.warn
+      ⚠️ React Router Future Flag Warning: React Router will begin wrapping state updates in `React.startTransition` in v7. You can use the `v7_startTransition` future flag to opt-in early. For more information, see https://reactrouter.com/v6/upgrading/future#v7_starttransition.
+
+      26 |   test('should render with default title', () => {
+      27 |     // Arrange
+    > 28 |     render(
+         |           ^
+      29 |       <BrowserRouter>
+      30 |         <Header />
+      31 |       </BrowserRouter>
+
+      at warnOnce (node_modules/react-router/lib/deprecations.ts:9:13)
+      at logDeprecation (node_modules/react-router/lib/deprecations.ts:14:3)
+      at Object.logV6DeprecationWarnings [as UNSAFE_logV6DeprecationWarnings] (node_modules/react-router/lib/deprecations.ts:26:5)
+      at node_modules/react-router-dom/index.tsx:816:25
+      at commitHookEffectListMount (node_modules/react-dom/cjs/react-dom.development.js:23189:26)
+      at commitPassiveMountOnFiber (node_modules/react-dom/cjs/react-dom.development.js:24970:11)
+      at commitPassiveMountEffects_complete (node_modules/react-dom/cjs/react-dom.development.js:24930:9)
+      at commitPassiveMountEffects_begin (node_modules/react-dom/cjs/react-dom.development.js:24917:7)
+      at commitPassiveMountEffects (node_modules/react-dom/cjs/react-dom.development.js:24905:3)
+      at flushPassiveEffectsImpl (node_modules/react-dom/cjs/react-dom.development.js:27078:3)
+      at flushPassiveEffects (node_modules/react-dom/cjs/react-dom.development.js:27023:14)
+      at node_modules/react-dom/cjs/react-dom.development.js:26808:9
+      at flushActQueue (node_modules/react/cjs/react.development.js:2667:24)
+      at act (node_modules/react/cjs/react.development.js:2582:11)
+      at actWithWarning (node_modules/react-dom/cjs/react-dom-test-utils.development.js:1740:10)
+      at node_modules/@testing-library/react/dist/act-compat.js:63:25
+      at renderRoot (node_modules/@testing-library/react/dist/pure.js:159:26)
+      at render (node_modules/@testing-library/react/dist/pure.js:246:10)
+      at Object.<anonymous> (src/components/__tests__/Header.test.jsx:28:11)
+
+    console.warn
+      ⚠️ React Router Future Flag Warning: Relative route resolution within Splat routes is changing in v7. You can use the `v7_relativeSplatPath` future flag to opt-in early. For more information, see https://reactrouter.com/v6/upgrading/future#v7_relativesplatpath.
+
+      26 |   test('should render with default title', () => {
+      27 |     // Arrange
+    > 28 |     render(
+         |           ^
+      29 |       <BrowserRouter>
+      30 |         <Header />
+      31 |       </BrowserRouter>
+
+      at warnOnce (node_modules/react-router/lib/deprecations.ts:9:13)
+      at logDeprecation (node_modules/react-router/lib/deprecations.ts:14:3)
+      at Object.logV6DeprecationWarnings [as UNSAFE_logV6DeprecationWarnings] (node_modules/react-router/lib/deprecations.ts:37:5)
+      at node_modules/react-router-dom/index.tsx:816:25
+      at commitHookEffectListMount (node_modules/react-dom/cjs/react-dom.development.js:23189:26)
+      at commitPassiveMountOnFiber (node_modules/react-dom/cjs/react-dom.development.js:24970:11)
+      at commitPassiveMountEffects_complete (node_modules/react-dom/cjs/react-dom.development.js:24930:9)
+      at commitPassiveMountEffects_begin (node_modules/react-dom/cjs/react-dom.development.js:24917:7)
+      at commitPassiveMountEffects (node_modules/react-dom/cjs/react-dom.development.js:24905:3)
+      at flushPassiveEffectsImpl (node_modules/react-dom/cjs/react-dom.development.js:27078:3)
+      at flushPassiveEffects (node_modules/react-dom/cjs/react-dom.development.js:27023:14)
+      at node_modules/react-dom/cjs/react-dom.development.js:26808:9
+      at flushActQueue (node_modules/react/cjs/react.development.js:2667:24)
+      at act (node_modules/react/cjs/react.development.js:2582:11)
+      at actWithWarning (node_modules/react-dom/cjs/react-dom-test-utils.development.js:1740:10)
+      at node_modules/@testing-library/react/dist/act-compat.js:63:25
+      at renderRoot (node_modules/@testing-library/react/dist/pure.js:159:26)
+      at render (node_modules/@testing-library/react/dist/pure.js:246:10)
+      at Object.<anonymous> (src/components/__tests__/Header.test.jsx:28:11)
+
+PASS src/pages/ContactPage.test.jsx
+PASS src/pages/__tests__/Home.test.jsx
+
+Test Suites: 4 passed, 4 total
+Tests:       9 passed, 9 total
+Snapshots:   0 total
+Time:        0.868 s, estimated 1 s
+Ran all test suites.

--- a/.reports/pr_report.md
+++ b/.reports/pr_report.md
@@ -1,0 +1,103 @@
+# Implementation Report for the Jira task
+
+## Test Results
+
+<details>
+<summary>Jest Execution Logs</summary>
+
+```
+
+> react-boilerplate@0.1.0 test
+> react-scripts test --watchAll=false
+
+PASS src/App.test.jsx
+PASS src/components/__tests__/Header.test.jsx
+  ● Console
+
+    console.warn
+      ⚠️ React Router Future Flag Warning: React Router will begin wrapping state updates in `React.startTransition` in v7. You can use the `v7_startTransition` future flag to opt-in early. For more information, see https://reactrouter.com/v6/upgrading/future#v7_starttransition.
+
+      26 |   test('should render with default title', () => {
+      27 |     // Arrange
+    > 28 |     render(
+         |           ^
+      29 |       <BrowserRouter>
+      30 |         <Header />
+      31 |       </BrowserRouter>
+
+      at warnOnce (node_modules/react-router/lib/deprecations.ts:9:13)
+      at logDeprecation (node_modules/react-router/lib/deprecations.ts:14:3)
+      at Object.logV6DeprecationWarnings [as UNSAFE_logV6DeprecationWarnings] (node_modules/react-router/lib/deprecations.ts:26:5)
+      at node_modules/react-router-dom/index.tsx:816:25
+      at commitHookEffectListMount (node_modules/react-dom/cjs/react-dom.development.js:23189:26)
+      at commitPassiveMountOnFiber (node_modules/react-dom/cjs/react-dom.development.js:24970:11)
+      at commitPassiveMountEffects_complete (node_modules/react-dom/cjs/react-dom.development.js:24930:9)
+      at commitPassiveMountEffects_begin (node_modules/react-dom/cjs/react-dom.development.js:24917:7)
+      at commitPassiveMountEffects (node_modules/react-dom/cjs/react-dom.development.js:24905:3)
+      at flushPassiveEffectsImpl (node_modules/react-dom/cjs/react-dom.development.js:27078:3)
+      at flushPassiveEffects (node_modules/react-dom/cjs/react-dom.development.js:27023:14)
+      at node_modules/react-dom/cjs/react-dom.development.js:26808:9
+      at flushActQueue (node_modules/react/cjs/react.development.js:2667:24)
+      at act (node_modules/react/cjs/react.development.js:2582:11)
+      at actWithWarning (node_modules/react-dom/cjs/react-dom-test-utils.development.js:1740:10)
+      at node_modules/@testing-library/react/dist/act-compat.js:63:25
+      at renderRoot (node_modules/@testing-library/react/dist/pure.js:159:26)
+      at render (node_modules/@testing-library/react/dist/pure.js:246:10)
+      at Object.<anonymous> (src/components/__tests__/Header.test.jsx:28:11)
+
+    console.warn
+      ⚠️ React Router Future Flag Warning: Relative route resolution within Splat routes is changing in v7. You can use the `v7_relativeSplatPath` future flag to opt-in early. For more information, see https://reactrouter.com/v6/upgrading/future#v7_relativesplatpath.
+
+      26 |   test('should render with default title', () => {
+      27 |     // Arrange
+    > 28 |     render(
+         |           ^
+      29 |       <BrowserRouter>
+      30 |         <Header />
+      31 |       </BrowserRouter>
+
+      at warnOnce (node_modules/react-router/lib/deprecations.ts:9:13)
+      at logDeprecation (node_modules/react-router/lib/deprecations.ts:14:3)
+      at Object.logV6DeprecationWarnings [as UNSAFE_logV6DeprecationWarnings] (node_modules/react-router/lib/deprecations.ts:37:5)
+      at node_modules/react-router-dom/index.tsx:816:25
+      at commitHookEffectListMount (node_modules/react-dom/cjs/react-dom.development.js:23189:26)
+      at commitPassiveMountOnFiber (node_modules/react-dom/cjs/react-dom.development.js:24970:11)
+      at commitPassiveMountEffects_complete (node_modules/react-dom/cjs/react-dom.development.js:24930:9)
+      at commitPassiveMountEffects_begin (node_modules/react-dom/cjs/react-dom.development.js:24917:7)
+      at commitPassiveMountEffects (node_modules/react-dom/cjs/react-dom.development.js:24905:3)
+      at flushPassiveEffectsImpl (node_modules/react-dom/cjs/react-dom.development.js:27078:3)
+      at flushPassiveEffects (node_modules/react-dom/cjs/react-dom.development.js:27023:14)
+      at node_modules/react-dom/cjs/react-dom.development.js:26808:9
+      at flushActQueue (node_modules/react/cjs/react.development.js:2667:24)
+      at act (node_modules/react/cjs/react.development.js:2582:11)
+      at actWithWarning (node_modules/react-dom/cjs/react-dom-test-utils.development.js:1740:10)
+      at node_modules/@testing-library/react/dist/act-compat.js:63:25
+      at renderRoot (node_modules/@testing-library/react/dist/pure.js:159:26)
+      at render (node_modules/@testing-library/react/dist/pure.js:246:10)
+      at Object.<anonymous> (src/components/__tests__/Header.test.jsx:28:11)
+
+PASS src/pages/ContactPage.test.jsx
+PASS src/pages/__tests__/Home.test.jsx
+
+Test Suites: 4 passed, 4 total
+Tests:       9 passed, 9 total
+Snapshots:   0 total
+Time:        0.868 s, estimated 1 s
+Ran all test suites.
+```
+</details>
+
+## Implementation Notes
+
+- Key changes implemented
+- Design decisions made
+- Components modified
+
+## Test Coverage
+
+- Number of tests: [Count]
+- Coverage percentage: [Percentage]
+
+## Known Limitations
+
+- List any known limitations or future improvements

--- a/src/App.js
+++ b/src/App.js
@@ -4,6 +4,7 @@ import './App.css';
 import Home from './pages/Home';
 import About from './pages/About';
 import NotFound from './pages/NotFound';
+import ContactPage from './pages/ContactPage';
 import Header from './components/Header';
 import Footer from './components/Footer';
 import logger from './utils/logger';
@@ -23,6 +24,7 @@ function App() {
           <Routes>
             <Route path="/" element={<Home />} />
             <Route path="/about" element={<About />} />
+            <Route path="/contact" element={<ContactPage />} />
             <Route path="*" element={<NotFound />} />
           </Routes>
         </main>

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -16,6 +16,7 @@ jest.mock('./components/Footer', () => () => <footer data-testid="footer">Footer
 jest.mock('./pages/Home', () => () => <div data-testid="home-page">Home Page</div>);
 jest.mock('./pages/About', () => () => <div data-testid="about-page">About Page</div>);
 jest.mock('./pages/NotFound', () => () => <div data-testid="not-found-page">Not Found Page</div>);
+jest.mock('./pages/ContactPage', () => () => <div data-testid="contact-page">Contact Page</div>);
 
 // Mock the logger
 jest.mock('./utils/logger', () => ({
@@ -46,6 +47,6 @@ describe('App Component', () => {
     expect(screen.getByTestId('routes')).toBeInTheDocument();
     expect(screen.getByTestId('header')).toBeInTheDocument();
     expect(screen.getByTestId('footer')).toBeInTheDocument();
-    expect(screen.getAllByTestId('route').length).toBe(3); // Home, About, NotFound routes
+    expect(screen.getAllByTestId('route').length).toBe(4); // Home, About, Contact, NotFound routes
   });
 });

--- a/src/pages/ContactPage.jsx
+++ b/src/pages/ContactPage.jsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import logger from '../utils/logger';
+
+/**
+ * ContactPage - A simple contact page with a form.
+ * @returns {React.Element} Rendered contact page.
+ */
+const ContactPage = () => {
+  logger.debug('Rendering ContactPage');
+  return (
+    <div className="contact-page">
+      <h1>Contact Us</h1>
+      <form data-testid="contact-form">
+        <div>
+          <label htmlFor="name">Name:</label>
+          <input type="text" id="name" name="name" />
+        </div>
+        <div>
+          <label htmlFor="email">Email:</label>
+          <input type="email" id="email" name="email" />
+        </div>
+        <div>
+          <label htmlFor="message">Message:</label>
+          <textarea id="message" name="message"></textarea>
+        </div>
+        <button type="submit">Submit</button>
+      </form>
+    </div>
+  );
+};
+
+ContactPage.propTypes = {};
+
+ContactPage.defaultProps = {};
+
+export default ContactPage;

--- a/src/pages/ContactPage.jsx
+++ b/src/pages/ContactPage.jsx
@@ -8,10 +8,23 @@ import logger from '../utils/logger';
  */
 const ContactPage = () => {
   logger.debug('Rendering ContactPage');
+
+  const handleSubmit = (event) => {
+    event.preventDefault();
+    const formData = {
+      name: event.target.elements.name.value,
+      email: event.target.elements.email.value,
+      message: event.target.elements.message.value,
+    };
+    logger.info('Contact form submitted', formData);
+    // In a real application, you would send this data to a backend service
+    alert('Thank you for your message!');
+  };
+
   return (
     <div className="contact-page">
       <h1>Contact Us</h1>
-      <form data-testid="contact-form">
+      <form data-testid="contact-form" onSubmit={handleSubmit}>
         <div>
           <label htmlFor="name">Name:</label>
           <input type="text" id="name" name="name" />
@@ -30,8 +43,6 @@ const ContactPage = () => {
   );
 };
 
-ContactPage.propTypes = {};
 
-ContactPage.defaultProps = {};
 
 export default ContactPage;

--- a/src/pages/ContactPage.test.jsx
+++ b/src/pages/ContactPage.test.jsx
@@ -1,8 +1,32 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import ContactPage from './ContactPage';
+import logger from '../utils/logger';
+
+// Mock the logger module
+jest.mock('../utils/logger', () => ({
+  debug: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+}));
 
 describe('ContactPage', () => {
+  beforeEach(() => {
+    // Clear mock calls before each test
+    logger.debug.mockClear();
+    logger.info.mockClear();
+    logger.warn.mockClear();
+    logger.error.mockClear();
+    // Mock window.alert
+    jest.spyOn(window, 'alert').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    // Restore original window.alert
+    window.alert.mockRestore();
+  });
+
   test('renders the contact page with a form', () => {
     render(<ContactPage />);
     expect(screen.getByRole('heading', { name: /contact us/i })).toBeInTheDocument();
@@ -11,5 +35,32 @@ describe('ContactPage', () => {
     expect(screen.getByLabelText(/email/i)).toBeInTheDocument();
     expect(screen.getByLabelText(/message/i)).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /submit/i })).toBeInTheDocument();
+    expect(logger.debug).toHaveBeenCalledWith('Rendering ContactPage');
+  });
+
+  test('submits the form and logs the data', () => {
+    render(<ContactPage />);
+
+    const nameInput = screen.getByLabelText(/name/i);
+    const emailInput = screen.getByLabelText(/email/i);
+    const messageTextarea = screen.getByLabelText(/message/i);
+    const submitButton = screen.getByRole('button', { name: /submit/i });
+
+    fireEvent.change(nameInput, { target: { value: 'John Doe' } });
+    fireEvent.change(emailInput, { target: { value: 'john.doe@example.com' } });
+    fireEvent.change(messageTextarea, { target: { value: 'This is a test message.' } });
+
+    fireEvent.click(submitButton);
+
+    expect(logger.info).toHaveBeenCalledTimes(1);
+    expect(logger.info).toHaveBeenCalledWith(
+      'Contact form submitted',
+      {
+        name: 'John Doe',
+        email: 'john.doe@example.com',
+        message: 'This is a test message.',
+      }
+    );
+    expect(window.alert).toHaveBeenCalledWith('Thank you for your message!');
   });
 });

--- a/src/pages/ContactPage.test.jsx
+++ b/src/pages/ContactPage.test.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import ContactPage from './ContactPage';
+
+describe('ContactPage', () => {
+  test('renders the contact page with a form', () => {
+    render(<ContactPage />);
+    expect(screen.getByRole('heading', { name: /contact us/i })).toBeInTheDocument();
+    expect(screen.getByTestId('contact-form')).toBeInTheDocument();
+    expect(screen.getByLabelText(/name/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/email/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/message/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /submit/i })).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
This PR implements the contact page as per Jira ticket DP-4.

**Key changes:**
- Created `src/pages/ContactPage.jsx` with a basic contact form.
- Created `src/pages/ContactPage.test.jsx` for unit testing the component.
- Integrated `ContactPage` into `App.js` with a new route `/contact`.
- Added logging to `ContactPage`.

**Test Coverage:** All existing tests pass, and new tests for `ContactPage` are included and passing.